### PR TITLE
Fix main asset bundle path on native Linux

### DIFF
--- a/SkyCoopClient/AssetManager.cs
+++ b/SkyCoopClient/AssetManager.cs
@@ -10,7 +10,7 @@ namespace SkyCoop
 {
     internal class AssetManager
     {
-        public static string s_MainBundlePath = "Mods\\skycoop";
+        public static string s_MainBundlePath = Path.Combine("Mods", "skycoop");
         public static AssetBundle s_MainBundle = null;
         public static GameObject s_PistolBulletPrefab = null;
         public static GameObject s_RevolverBulletPrefab = null;


### PR DESCRIPTION
## Problem

`AssetManager.s_MainBundlePath` is hardcoded as `"Mods\\skycoop"`. On Windows (and under Proton) that works, but on the **native Linux build** of The Long Dark the backslash is not a path separator, so loading the main bundle throws:

```
System.IO.FileNotFoundException: Could not find file '.../TheLongDark/Mods\skycoop'
```

The mod then boots without its UI, kill feed, or player prefabs ("Can't create UI!", "Can't load KillFeedElement!").

## Fix

Use `Path.Combine("Mods", "skycoop")` — identical behavior on Windows, correct on Linux/macOS.

## Verified

TLD **2.55 native Linux** (`tld.x86_64`, Unity 6000.0.60f1) with **MelonLoader 0.7.3 Linux** (`LD_PRELOAD=MelonLoader.Bootstrap.so`), bundle built from the SkyCoopBundles project for `StandaloneLinux64`:

```
[Sky Co-op REBORN] Main Asset Bundle is loaded.
[Sky Co-op REBORN] Canvas UI created!
[Sky Co-op REBORN] KillFeedElement loaded!
[Sky Co-op REBORN] KillFeedElementKill loaded!
[Sky Co-op REBORN] KillFeedElementDead loaded!
```

Thanks for the great mod — Reborn runs nicely on the native Linux build with this one change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)